### PR TITLE
Change map to tomap

### DIFF
--- a/modules/dev-instance/main.tf
+++ b/modules/dev-instance/main.tf
@@ -4,7 +4,8 @@ resource "aws_instance" "instance" {
 
   tags = merge(
       var.tags,
-      map("Env", "Dev")
+      tomap({"Env" = "Dev"})
+
   )
 
   root_block_device {

--- a/modules/qa-instance/main.tf
+++ b/modules/qa-instance/main.tf
@@ -4,7 +4,7 @@ resource "aws_instance" "instance" {
 
   tags = merge(
       var.tags,
-      map("Env", "QA")
+      tomap({"Env" = "QA"})
   )
 
   root_block_device {


### PR DESCRIPTION
Previous code gives the error: 
│ Call to function "map" failed: the "map" function was deprecated in Terraform v0.12 and is no longer available; use tomap({ ... }) syntax to write a literal
│ map.

Changed map function to tomap